### PR TITLE
fix: avoid panic for short sandbox users

### DIFF
--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -205,7 +205,9 @@ func validAndRestValueOfSandbox(sb *Sandbox) error {
 
 func (sb *Sandbox) ToString() string {
 	sbTmp := *sb
-	sbTmp.User = sbTmp.User[:20]
+	if len(sbTmp.User) > 20 {
+		sbTmp.User = sbTmp.User[:20]
+	}
 	sbStr, _ := json.Marshal(sbTmp)
 	return string(sbStr)
 }

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -1,0 +1,38 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSandboxToStringAllowsShortUser(t *testing.T) {
+	sb := &Sandbox{User: "u1"}
+
+	got := sb.ToString()
+
+	var payload struct {
+		User string `json:"user"`
+	}
+	if err := json.Unmarshal([]byte(got), &payload); err != nil {
+		t.Fatalf("failed to unmarshal sandbox string: %v", err)
+	}
+	if payload.User != "u1" {
+		t.Fatalf("expected short user to be preserved, got %q", payload.User)
+	}
+}
+
+func TestSandboxToStringTruncatesLongUser(t *testing.T) {
+	sb := &Sandbox{User: "1234567890123456789012345"}
+
+	got := sb.ToString()
+
+	var payload struct {
+		User string `json:"user"`
+	}
+	if err := json.Unmarshal([]byte(got), &payload); err != nil {
+		t.Fatalf("failed to unmarshal sandbox string: %v", err)
+	}
+	if payload.User != "12345678901234567890" {
+		t.Fatalf("expected long user to be truncated to 20 characters, got %q", payload.User)
+	}
+}


### PR DESCRIPTION
## Summary
- Guard `Sandbox.ToString()` before truncating the user key.
- Add coverage for short user keys and existing long-user truncation behavior.

## Tests
- `go test -vet=off ./pkg/sandbox`

Note: default `go test ./pkg/sandbox` is currently blocked by an existing upstream vet issue in `pkg/sandbox/controller.go` unrelated to this change.