### PR TITLE
fix(e2b): bind the declared query parameters on GET /v2/sandboxes

### DIFF
--- a/pkg/api/e2b/sandbox.go
+++ b/pkg/api/e2b/sandbox.go
@@ -62,6 +62,26 @@ func (a *Handler) ListSandboxes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// GET /v2/sandboxes declares metadata, state, nextToken and limit (see
+	// api.GetV2SandboxesParams, generated from the e2b description). They were never
+	// read off the request, so every call returned the caller's whole list and a
+	// filter that matched nothing came back looking like a filter that matched
+	// everything.
+	params, perr := parseListParams(r.URL.Query())
+	if perr != "" {
+		sendAPIError(w, http.StatusBadRequest, perr)
+		return
+	}
+	var metaFilter map[string]string
+	if params.Metadata != nil {
+		var ok bool
+		metaFilter, ok = parseMetadataFilter(*params.Metadata)
+		if !ok {
+			sendAPIError(w, http.StatusBadRequest, "invalid metadata filter, expected URL-encoded key=value pairs")
+			return
+		}
+	}
+
 	sbs, err := a.controller.List(user)
 	if err != nil {
 		sendAPIError(w, http.StatusInternalServerError, fmt.Sprintf("failed to list sandboxes: %v", err))
@@ -72,6 +92,13 @@ func (a *Handler) ListSandboxes(w http.ResponseWriter, r *http.Request) {
 	for _, sb := range sbs {
 		apiSbx := a.convertToE2BSandbox(sb)
 		apiSandboxes = append(apiSandboxes, apiSbx)
+	}
+
+	// Filter AFTER conversion: state and metadata are read from the e2b shape, so
+	// the filter sees exactly what the caller sees.
+	apiSandboxes, nextToken := applyListFilters(apiSandboxes, params, metaFilter)
+	if nextToken != "" {
+		w.Header().Set("X-Next-Token", nextToken)
 	}
 
 	sendAPIOK(w, http.StatusOK, apiSandboxes)

--- a/pkg/api/e2b/sandbox_list_filter.go
+++ b/pkg/api/e2b/sandbox_list_filter.go
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2025 The https://github.com/agent-sandbox/agent-sandbox Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2b
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/agent-sandbox/agent-sandbox/pkg/api/e2b/api"
+)
+
+// GetV2SandboxesParams is generated from the e2b OpenAPI description and declares
+// metadata, state, nextToken and limit on GET /v2/sandboxes. Nothing bound them to
+// the request, so every query was answered with the caller's full sandbox list.
+//
+// These helpers parse and apply exactly those four, matching the contract the
+// generated type documents.
+
+// parseListParams reads the declared query parameters off the request.
+//
+// state is an array in the OpenAPI description. Both encodings real clients emit
+// are accepted: repeated (state=running&state=paused) and comma-separated
+// (state=running,paused).
+//
+// An unparseable limit or an unknown state is reported rather than ignored: the
+// contract says these are typed, and silently discarding a filter the caller asked
+// for is how an unfiltered response gets mistaken for an empty one.
+func parseListParams(q url.Values) (*api.GetV2SandboxesParams, string) {
+	p := &api.GetV2SandboxesParams{}
+
+	if raw, ok := q["metadata"]; ok && len(raw) > 0 && raw[0] != "" {
+		v := raw[0]
+		p.Metadata = &v
+	}
+
+	if raw, ok := q["state"]; ok {
+		var states []api.SandboxState
+		for _, item := range raw {
+			for _, part := range strings.Split(item, ",") {
+				part = strings.TrimSpace(part)
+				if part == "" {
+					continue
+				}
+				st := api.SandboxState(part)
+				if !st.Valid() {
+					return nil, "invalid state: " + part
+				}
+				states = append(states, st)
+			}
+		}
+		if len(states) > 0 {
+			p.State = &states
+		}
+	}
+
+	if raw := strings.TrimSpace(q.Get("limit")); raw != "" {
+		n, err := strconv.ParseInt(raw, 10, 32)
+		if err != nil || n < 1 {
+			return nil, "invalid limit: " + raw
+		}
+		limit := api.PaginationLimit(n)
+		p.Limit = &limit
+	}
+
+	if raw := strings.TrimSpace(q.Get("nextToken")); raw != "" {
+		tok := api.PaginationNextToken(raw)
+		p.NextToken = &tok
+	}
+
+	return p, ""
+}
+
+// parseMetadataFilter decodes the metadata query into key/value pairs.
+//
+// The generated type documents the format as `user=abc&app=prod` with each key and
+// value URL encoded, so the value arrives double-encoded: once for the pair and once
+// for the surrounding query string. net/url has already undone the outer layer by the
+// time this sees it, so exactly one decode remains.
+//
+// A malformed filter returns ok=false and the caller answers 400. It must never
+// degrade to "no filter" - a caller asking for a workspace that does not exist has to
+// get an empty list, never somebody else's sandboxes.
+func parseMetadataFilter(raw string) (map[string]string, bool) {
+	if raw == "" {
+		return nil, true
+	}
+	out := map[string]string{}
+	for _, pair := range strings.Split(raw, "&") {
+		if pair == "" {
+			continue
+		}
+		k, v, found := strings.Cut(pair, "=")
+		if !found || k == "" {
+			return nil, false
+		}
+		dk, err := url.QueryUnescape(k)
+		if err != nil {
+			return nil, false
+		}
+		dv, err := url.QueryUnescape(v)
+		if err != nil {
+			return nil, false
+		}
+		out[dk] = dv
+	}
+	return out, true
+}
+
+// metadataMatches reports whether every requested pair is present on the sandbox.
+// Subset semantics, matching e2b: a sandbox carrying extra keys still matches.
+func metadataMatches(sbxMeta map[string]string, want map[string]string) bool {
+	for k, v := range want {
+		got, ok := sbxMeta[k]
+		if !ok || got != v {
+			return false
+		}
+	}
+	return true
+}
+
+// stateMatches reports whether the sandbox is in one of the requested states.
+func stateMatches(state api.SandboxState, want []api.SandboxState) bool {
+	for _, w := range want {
+		if state == w {
+			return true
+		}
+	}
+	return false
+}
+
+// applyListFilters filters, then pages. Order matters: limit has to apply to what
+// survived filtering, or a limit could hide the very rows a filter selected.
+//
+// nextToken is a plain index cursor here. It is opaque to clients by contract, and
+// the list is already sorted CreatedAt-descending by the controller, so an index is
+// stable enough for paging a single caller's sandboxes. Returns the page and the
+// token for the next one ("" when the page is the last).
+func applyListFilters(in []*api.Sandbox, p *api.GetV2SandboxesParams, meta map[string]string) ([]*api.Sandbox, string) {
+	out := make([]*api.Sandbox, 0, len(in))
+	for _, sbx := range in {
+		if len(meta) > 0 && !metadataMatches(sbx.Metadata, meta) {
+			continue
+		}
+		if p.State != nil && !stateMatches(sbx.State, *p.State) {
+			continue
+		}
+		out = append(out, sbx)
+	}
+
+	start := 0
+	if p.NextToken != nil {
+		if n, err := strconv.Atoi(string(*p.NextToken)); err == nil && n > 0 {
+			start = n
+		}
+	}
+	if start >= len(out) {
+		return []*api.Sandbox{}, ""
+	}
+	out = out[start:]
+
+	if p.Limit != nil && int(*p.Limit) < len(out) {
+		next := strconv.Itoa(start + int(*p.Limit))
+		return out[:*p.Limit], next
+	}
+	return out, ""
+}

--- a/pkg/api/e2b/sandbox_list_filter_test.go
+++ b/pkg/api/e2b/sandbox_list_filter_test.go
@@ -1,0 +1,144 @@
+package e2b
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/agent-sandbox/agent-sandbox/pkg/api/e2b/api"
+)
+
+// The fleet under test: two sandboxes for the same caller, differing only in the
+// metadata that identifies their owner - which is the case the unfiltered endpoint
+// could not distinguish.
+func fixture() []*api.Sandbox {
+	return []*api.Sandbox{
+		{
+			SandboxID: "aaa",
+			State:     api.Running,
+			Metadata:  map[string]string{"workspace": "scratch/alpha", "name": "alpha"},
+		},
+		{
+			SandboxID: "bbb",
+			State:     api.Paused,
+			Metadata:  map[string]string{"workspace": "scratch/beta", "name": "beta"},
+		},
+	}
+}
+
+func run(t *testing.T, rawQuery string) ([]*api.Sandbox, string) {
+	t.Helper()
+	q, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		t.Fatalf("bad test query %q: %v", rawQuery, err)
+	}
+	p, perr := parseListParams(q)
+	if perr != "" {
+		t.Fatalf("unexpected param error for %q: %s", rawQuery, perr)
+	}
+	var meta map[string]string
+	if p.Metadata != nil {
+		var ok bool
+		meta, ok = parseMetadataFilter(*p.Metadata)
+		if !ok {
+			t.Fatalf("unexpected metadata parse failure for %q", rawQuery)
+		}
+	}
+	return applyListFilters(fixture(), p, meta)
+}
+
+func TestNoFilterReturnsAll(t *testing.T) {
+	got, _ := run(t, "")
+	if len(got) != 2 {
+		t.Fatalf("want 2, got %d", len(got))
+	}
+}
+
+// The headline case. Before the fix this returned 2.
+func TestMetadataSelectsOne(t *testing.T) {
+	got, _ := run(t, "metadata=workspace%3Dscratch%252Falpha")
+	if len(got) != 1 {
+		t.Fatalf("want 1, got %d", len(got))
+	}
+	if got[0].SandboxID != "aaa" {
+		t.Fatalf("want aaa, got %s", got[0].SandboxID)
+	}
+}
+
+// The dangerous case: a filter matching nothing must return nothing, never the
+// unfiltered set.
+func TestMetadataNoMatchReturnsEmpty(t *testing.T) {
+	got, _ := run(t, "metadata=workspace%3DNO_SUCH_WORKSPACE")
+	if len(got) != 0 {
+		t.Fatalf("want 0, got %d", len(got))
+	}
+}
+
+func TestMetadataUnknownKeyReturnsEmpty(t *testing.T) {
+	got, _ := run(t, "metadata=no_such_key%3Dwhatever")
+	if len(got) != 0 {
+		t.Fatalf("want 0, got %d", len(got))
+	}
+}
+
+// Subset semantics: extra keys on the sandbox must not prevent a match, and all
+// requested pairs must hold.
+func TestMetadataMultiPair(t *testing.T) {
+	if got, _ := run(t, "metadata=workspace%3Dscratch%252Falpha%26name%3Dalpha"); len(got) != 1 {
+		t.Fatalf("both pairs match: want 1, got %d", len(got))
+	}
+	if got, _ := run(t, "metadata=workspace%3Dscratch%252Falpha%26name%3Dbeta"); len(got) != 0 {
+		t.Fatalf("one pair contradicts: want 0, got %d", len(got))
+	}
+}
+
+func TestStateFilter(t *testing.T) {
+	if got, _ := run(t, "state=paused"); len(got) != 1 || got[0].SandboxID != "bbb" {
+		t.Fatalf("state=paused should select bbb, got %v", got)
+	}
+	if got, _ := run(t, "state=running,paused"); len(got) != 2 {
+		t.Fatalf("comma form should select both, got %d", len(got))
+	}
+	if got, _ := run(t, "state=running&state=paused"); len(got) != 2 {
+		t.Fatalf("repeated form should select both, got %d", len(got))
+	}
+}
+
+func TestInvalidValuesAreRejectedNotIgnored(t *testing.T) {
+	if _, perr := parseListParams(url.Values{"state": {"nonsense"}}); perr == "" {
+		t.Fatal("invalid state must be an error, not silently ignored")
+	}
+	if _, perr := parseListParams(url.Values{"limit": {"0"}}); perr == "" {
+		t.Fatal("limit=0 must be an error")
+	}
+	if _, perr := parseListParams(url.Values{"limit": {"abc"}}); perr == "" {
+		t.Fatal("non-numeric limit must be an error")
+	}
+	if _, ok := parseMetadataFilter("this-is-not-key-value"); ok {
+		t.Fatal("malformed metadata must be rejected, never treated as no filter")
+	}
+}
+
+func TestLimitAndPaging(t *testing.T) {
+	got, next := run(t, "limit=1")
+	if len(got) != 1 {
+		t.Fatalf("limit=1: want 1, got %d", len(got))
+	}
+	if next != "1" {
+		t.Fatalf("want nextToken 1, got %q", next)
+	}
+	page2, next2 := run(t, "limit=1&nextToken="+next)
+	if len(page2) != 1 || page2[0].SandboxID == got[0].SandboxID {
+		t.Fatalf("second page must be the other sandbox, got %v", page2)
+	}
+	if next2 != "" {
+		t.Fatalf("last page must have no nextToken, got %q", next2)
+	}
+}
+
+// limit must not be able to hide rows a filter selected.
+func TestLimitAppliesAfterFilter(t *testing.T) {
+	got, _ := run(t, "metadata=workspace%3Dscratch%252Fbeta&limit=5")
+	if len(got) != 1 || got[0].SandboxID != "bbb" {
+		t.Fatalf("want just bbb, got %v", got)
+	}
+}


### PR DESCRIPTION
# fix(e2b): bind the declared query parameters on `GET /v2/sandboxes`

## What's wrong

`api.GetV2SandboxesParams` — generated from the e2b description — declares `metadata`,
`state`, `nextToken` and `limit`. `ListSandboxes` never reads `r.URL.Query()`, so none of
them are bound and every call returns the caller's entire sandbox list:

```go
func (a *Handler) ListSandboxes(w http.ResponseWriter, r *http.Request) {
	user := auth.GetUserTokenFromContext(r.Context())
	sbs, err := a.controller.List(user)   // no query parameters read
	...
}
```

`grep -rn 'URL.Query' pkg/api/e2b/` returns nothing.

The failure inverts safely-looking: **a filter that matches nothing is answered with
everything.** A client asking "is there a sandbox for workspace X?" is told yes and handed
a different sandbox. Because `limit` is also ignored, every lookup transfers the caller's
whole fleet.

## Reproduction

Against 0.8.0, two sandboxes differing only in `metadata.workspace`. All eight requests
returned **both** rows:

| request | returned | expected |
|---|---|---|
| `?limit=100` | 2 | 2 |
| `?metadata=workspace%3D<existing>` | 2 | **1** |
| `?metadata=workspace%3DNO_SUCH_WORKSPACE` | 2 | **0** |
| `?metadata=no_such_key%3Dwhatever` | 2 | **0** |
| `?metadata=this-is-not-key-value` | 2 | **400 or 0** |
| `?state=paused` (both running) | 2 | **0** |
| `?state=nonsense` | 2 | **400** |
| `?limit=1` | 2 | **1** |

A two-sandbox fleet is deliberate: with only one match possible, "returned 2" cannot be
explained by the filter coincidentally matching everything.

## The change

Binds parameters that already exist. No new API surface, no change to the generated types.

- **metadata** — `key=value&key2=value2`, each key and value URL-encoded, per the generated
  type's own doc comment. Subset match, so a sandbox carrying extra keys still matches. A
  filter matching nothing returns an empty list.
- **state** — accepts both `state=a&state=b` and `state=a,b`; unknown values are rejected.
- **limit** — applied **after** filtering, so it cannot hide rows a filter selected.
- **nextToken** — index cursor over the controller's existing `CreatedAt`-descending order,
  returned in `X-Next-Token` when a page was truncated.

Malformed input returns **400** rather than being ignored. Silently dropping a filter is
exactly what turns an unfiltered response into one a caller reads as authoritative.

## Tests

`pkg/api/e2b/sandbox_list_filter_test.go` — 9 tests covering each parameter, the
empty-result cases, subset matching, both `state` encodings, paging, and that `limit`
applies after filtering.

**Mutation-tested.** With `applyListFilters` reverted to returning its input unchanged —
current behaviour — 7 of the 9 fail:

```
--- FAIL: TestMetadataSelectsOne
--- FAIL: TestMetadataNoMatchReturnsEmpty
--- FAIL: TestMetadataUnknownKeyReturnsEmpty
--- FAIL: TestMetadataMultiPair
--- FAIL: TestStateFilter
--- FAIL: TestLimitAndPaging
--- FAIL: TestLimitAppliesAfterFilter
```

So they detect the defect rather than passing vacuously.

`go build ./...`, `go vet ./pkg/api/e2b/` and `go test ./pkg/api/e2b/` are clean.

## Open question for maintainers

`nextToken` is an index cursor. That is stable for a single caller against the already-sorted
list, but if you would rather it were opaque and creation-time-based (so concurrent
create/delete cannot shift a page), say so and I will rework it — it is contained to
`applyListFilters`.

## Note on scope

`List(user)` already scopes by `sbx-user`, so this is not a cross-tenant leak between API
tokens. It is a leak **within** a token's own set, which matters for deployments that use one
token across many end users and carry per-user identity in `metadata`.
