### PR TITLE
feat(ui): filter the sandboxes list by ingested metadata labels

### DIFF
--- a/ui/src/pages/SandboxesPage.tsx
+++ b/ui/src/pages/SandboxesPage.tsx
@@ -266,6 +266,8 @@ export default function SandboxesPage() {
   const [isAutoRefresh, setIsAutoRefresh] = useState(true)
   const [refreshIntervalMs, setRefreshIntervalMs] = useState(5000)
   const [sortKey, setSortKey] = useState<SandboxSortKey>('created-desc')
+  const [filterKey, setFilterKey] = useState('')
+  const [filterValue, setFilterValue] = useState('')
 
   const inflightNamesRef = useRef<Set<string>>(new Set())
   const requestSerialByNameRef = useRef<Record<string, number>>({})
@@ -443,8 +445,37 @@ export default function SandboxesPage() {
     }
   }, [metricsByName, sandboxes])
 
+  const metadataFacets = useMemo(() => {
+    const byKey = new Map<string, Set<string>>()
+    for (const sandbox of sandboxes) {
+      for (const [key, value] of Object.entries(sandbox.metadata ?? {})) {
+        if (!byKey.has(key)) {
+          byKey.set(key, new Set())
+        }
+        byKey.get(key)?.add(value)
+      }
+    }
+    return [...byKey.entries()]
+      .map(([key, values]) => [key, [...values].sort((a, b) => a.localeCompare(b))] as const)
+      .sort((a, b) => a[0].localeCompare(b[0]))
+  }, [sandboxes])
+
+  const filterValues = useMemo(
+    () => metadataFacets.find(([key]) => key === filterKey)?.[1] ?? [],
+    [metadataFacets, filterKey],
+  )
+
   const sortedSandboxes = useMemo(() => {
-    const next = [...sandboxes]
+    const next = sandboxes.filter((sandbox) => {
+      if (filterKey === '') {
+        return true
+      }
+      const value = (sandbox.metadata ?? {})[filterKey]
+      if (value === undefined) {
+        return false
+      }
+      return filterValue === '' || value === filterValue
+    })
 
     next.sort((a, b) => {
       if (sortKey === 'created-desc') {
@@ -465,7 +496,7 @@ export default function SandboxesPage() {
     })
 
     return next
-  }, [sandboxes, sortKey])
+  }, [sandboxes, sortKey, filterKey, filterValue])
 
   const isDeleteDisabled = (sandboxName: string) => !sandboxName || Boolean(deletingName)
 
@@ -607,6 +638,45 @@ export default function SandboxesPage() {
                 </label>
 
                 <label className="flex items-center gap-2">
+                  <span className="text-sm">Label</span>
+                  <select
+                    className="select select-sm select-bordered"
+                    value={filterKey}
+                    onChange={(event) => {
+                      setFilterKey(event.target.value)
+                      setFilterValue('')
+                    }}
+                  >
+                    <option value="">All sandboxes</option>
+                    {metadataFacets.map(([key]) => (
+                      <option key={key} value={key}>
+                        {key}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                {filterKey !== '' && (
+                  <label className="flex items-center gap-2">
+                    <input
+                      className="input input-sm input-bordered w-52"
+                      type="search"
+                      list="sandbox-label-values"
+                      placeholder={`${filterValues.length} value${filterValues.length === 1 ? '' : 's'} — type to search`}
+                      value={filterValue}
+                      onChange={(event) => {
+                        setFilterValue(event.target.value)
+                      }}
+                    />
+                    <datalist id="sandbox-label-values">
+                      {filterValues.map((value) => (
+                        <option key={value} value={value} />
+                      ))}
+                    </datalist>
+                  </label>
+                )}
+
+                <label className="flex items-center gap-2">
                   <span className="text-sm">Sort</span>
                   <select className="select select-sm select-bordered" value={sortKey} onChange={handleSortChange}>
                     <option value="created-desc">Created (newest first)</option>
@@ -667,7 +737,7 @@ export default function SandboxesPage() {
                   {sortedSandboxes.length === 0 ? (
                     <tr>
                       <td className="text-center text-base-content/70" colSpan={10}>
-                        {isListLoading ? 'Loading sandboxes...' : 'No sandboxes found.'}
+                        {isListLoading ? 'Loading sandboxes...' : filterKey !== '' && sandboxes.length > 0 ? 'No sandboxes match the selected label.' : 'No sandboxes found.'}
                       </td>
                     </tr>
                   ) : (
@@ -688,6 +758,27 @@ export default function SandboxesPage() {
                                 {sandbox.id || '-'}
                               </a>
                             </div>
+                            {sandbox.metadata && Object.keys(sandbox.metadata).length > 0 && (
+                              <div className="mt-1 flex flex-wrap gap-1">
+                                {Object.entries(sandbox.metadata).map(([key, value]) => {
+                                  const isActive = filterKey === key && filterValue === value
+                                  return (
+                                    <button
+                                      key={key}
+                                      className={`badge badge-sm font-normal ${isActive ? 'badge-primary' : 'badge-ghost'}`}
+                                      type="button"
+                                      title={isActive ? 'Clear filter' : `Show only ${key}=${value}`}
+                                      onClick={() => {
+                                        setFilterKey(isActive ? '' : key)
+                                        setFilterValue(isActive ? '' : value)
+                                      }}
+                                    >
+                                      {key}={value}
+                                    </button>
+                                  )
+                                })}
+                              </div>
+                            )}
                           </td>
                           <td>{sandbox.template || '-'}</td>
                           <td>{sandbox.image || '-'}</td>


### PR DESCRIPTION
## What

Faceted filtering for the Sandboxes list, built from the metadata labels that were actually ingested — so a deployment serving many clients/teams can tell its sandboxes apart in the UI.

- A **Label** select lists the metadata **keys** present across the loaded sandboxes — one entry per key, so it stays short however many sandboxes exist.
- Picking a key reveals a **type-to-search value box** (native `<datalist>`), so a high-cardinality key with hundreds of distinct values is searched, not scrolled. The placeholder shows how many values exist.
- Key alone matches "carries this label at all"; key + value is an exact pair match.
- Every row now shows its labels as **chips** — click one to apply that exact pair, click the active (highlighted) one to clear. Applied filters stay visible both in the controls and on the rows.
- The empty state distinguishes "No sandboxes match the selected label" from "No sandboxes found".

No new dependencies; DaisyUI classes matching the existing page; `tsc` and `eslint` clean.

## Why two controls instead of one dropdown

Plain selects degrade past ~10–15 options, and metadata values are unbounded (a per-user `workspace` key has one value per sandbox). The established pattern is facet-then-search: a short category list, type-to-search within a long value list, applied filters always visible. Keys are few by nature; values get the searchable control.

## Screenshots

Key picked (`client`) — chips visible on rows, value box showing the count:

![facet picked](https://raw.githubusercontent.com/Idosegal/agent-sandbox/pr-assets-ui-filter/pr-1-facet.png)

Value entered — list narrowed to the exact pair:

![filtered](https://raw.githubusercontent.com/Idosegal/agent-sandbox/pr-assets-ui-filter/pr-2-value.png)

## Tested

Built into the 0.8.2 image and run against a live EKS deployment: facet options derived correctly from mixed real metadata, exact-pair and key-only matching verified, chip toggle and empty state verified. (Screenshots above are from that deployment, with internal registry/IDs blurred.)

## Scope note

Filtering is client-side over the already-loaded list, consistent with how the page works today. For very large fleets the natural follow-up is delegating to the server-side metadata filter the e2b list endpoint gained in 0.8.2 (#11) — left out here to keep this UI-only.

## Unrelated observation while building this

The 0.8.2 release binary self-reports **v0.8.1**: `pkg/config/config.go:36` still has `const Version = "0.8.1"` on the `0.8.2` tag, which is what the UI footer displays. Not touched in this PR to keep it single-purpose — possibly worth injecting from the release tag at build time (`-ldflags`) so it cannot drift again. Happy to send that separately if useful.
